### PR TITLE
Only clear overlays when point has left the error region

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -89,8 +89,9 @@ Return the displayed phantom."
   "Delete PHANTOM if its region doesn't contain point.
 
 Returns the overlay removed or nil."
-  (and (not (flycheck-inline--contains-point phantom))
-       (delete-overlay phantom)))
+  (if (flycheck-inline--contains-point phantom)
+      nil
+    (progn (delete-overlay phantom) t)))
 
 (defun flycheck-inline-indent-message (offset msg)
   "Indent all lines of MSG by OFFSET spaces.

--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -69,7 +69,7 @@ Return the displayed phantom."
     (overlay-put ov 'error err)
     ov))
 
-(defun flycheck-inline--on-point (phantom &optional pt)
+(defun flycheck-inline--contains-point (phantom &optional pt)
   "Whether the given error overlay contains the position PT otherwise `(point)'"
   (let* ((pos (or pt (point)))
          (err (overlay-get phantom 'error))
@@ -88,9 +88,9 @@ Return the displayed phantom."
 (defun flycheck-inline-phantom-delete (phantom)
   "Delete PHANTOM if its region doesn't contain point.
 
-Returns whether the overlay should be kept or not."
-  (or (flycheck-inline--on-point phantom)
-      (not (delete-overlay phantom))))
+Returns the overlay removed or nil."
+  (and (not (flycheck-inline--contains-point phantom))
+       (delete-overlay phantom)))
 
 (defun flycheck-inline-indent-message (offset msg)
   "Indent all lines of MSG by OFFSET spaces.
@@ -182,7 +182,7 @@ POS defaults to point."
 (defun flycheck-inline-clear-phantoms ()
   "Remove all phantoms from buffer that don't contain point."
   (setq flycheck-inline--phantoms
-        (seq-filter #'flycheck-inline-phantom-delete flycheck-inline--phantoms)))
+        (seq-remove #'flycheck-inline-phantom-delete flycheck-inline--phantoms)))
 
 
 


### PR DESCRIPTION
Fixes #16 by adding the flycheck error as a property to each overlay and only clearing overlays whose error doesn't contain point. This results in, IMO, a much smoother experience with this mode. Hopefully there isn't a fundamental issue with my approach. I've only tested in `emacs-lisp-mode` and `rustic-mode` (with LSP). Works for sub-line and multi-line errors alike. Not sure if this should be a toggle or if others consider it a direct upgrade as I do.

Here's a short screencast of rust code in DOOM with a few errors that hopefully demonstrates the change for someone that's used this mode previously:
![flycheck-pr](https://user-images.githubusercontent.com/3489148/85367349-132f2500-b4f7-11ea-91a5-bc1f10f39901.gif)
