### PR TITLE
Require compile for faces

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -39,6 +39,7 @@
 
 (require 'flycheck)
 (require 'seq)
+(require 'compile)
 
 
 ;;; Displaying line-long overlays (phantoms)


### PR DESCRIPTION
Fix #20.

This simply requires `compile.el` so that we will have the `compilation-*` faces available. However, I am not sure if it is the best fix. Maybe we should instead inherit some faces defined in `flycheck`?

Thank you!