### PR TITLE
Turn off help-echo to prevent error msgs from showing in echo area

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -256,11 +256,13 @@ directly below the error reported location."
   (cond
    ;; Use our display function.
    (flycheck-inline-mode
+    (setq-local flycheck-help-echo-function nil)
     (setq-local flycheck-display-errors-function #'flycheck-inline-display-errors)
     (setq-local flycheck-clear-displayed-errors-function #'flycheck-inline-hide-errors))
    ;; Reset the display function and remove ourselves from all hooks but only
    ;; if the mode is still active.
    ((not flycheck-inline-mode)
+    (kill-local-variable 'flycheck-help-echo-function)
     (kill-local-variable 'flycheck-display-errors-function)
     (kill-local-variable 'flycheck-clear-displayed-errors-function)
     (flycheck-inline-hide-errors))))


### PR DESCRIPTION
If we don't do this, the long multiline error messages will be shown inline in the buffer and a giant minibuffer popup, which is super annoying.

Before:

<img width="1747" alt="Screenshot 2024-11-04 at 1 41 12 PM" src="https://github.com/user-attachments/assets/c1c8ea63-a8ac-45b8-a4ba-289f72879499">

After:

<img width="1542" alt="Screenshot 2024-11-04 at 1 42 17 PM" src="https://github.com/user-attachments/assets/0eba1e80-c386-41e1-abf2-2794a7b5ee53">
