### PR TITLE
Filter out related errors not on the same line and column

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -229,9 +229,22 @@ POS defaults to point."
 
 ERRORS is a list of `flycheck-error' objects."
   (flycheck-inline-hide-errors)
-  (mapc #'flycheck-inline-display-error
-        (seq-uniq
-         (seq-mapcat #'flycheck-related-errors errors))))
+  (let* ((lines (mapcar 'flycheck-error-line errors))
+         (line-range (cons (apply 'min lines) (apply 'max lines)))
+         (columns (mapcar 'flycheck-error-column errors))
+         (column-range (cons (apply 'min columns) (apply 'max columns))))
+    (mapc #'flycheck-inline-display-error
+          (seq-filter
+           (lambda (error)
+             (let ((line (flycheck-error-line error))
+                   (column (flycheck-error-column error)))
+               (and
+                (>= line (car line-range))
+                (<= line (cdr line-range))
+                (>= column (car column-range))
+                (<= column (cdr column-range)))))
+           (seq-uniq
+            (seq-mapcat #'flycheck-related-errors errors))))))
 
 
 ;;; Global and local minor modes


### PR DESCRIPTION
Many LSP servers will return diagnostics on different lines and columns but having the same group. If we naively take all the related errors without filtering them further against the line and column ranges of the errors at point, flycheck inline may show multiple inline popups, which is very annoying.

## Before

<img width="854" alt="Screenshot 2024-11-04 at 2 07 41 PM" src="https://github.com/user-attachments/assets/aebdced3-99a9-4b67-a670-4ed57408214c">


## After

<img width="854" alt="Screenshot 2024-11-04 at 2 07 51 PM" src="https://github.com/user-attachments/assets/4ac2fb2c-a994-49a3-8d7b-73b65320baa4">
