### PR TITLE
Fix wrong type argument when errors have no columns

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -231,8 +231,9 @@ ERRORS is a list of `flycheck-error' objects."
   (flycheck-inline-hide-errors)
   (let* ((lines (mapcar 'flycheck-error-line errors))
          (line-range (cons (apply 'min lines) (apply 'max lines)))
-         (columns (mapcar 'flycheck-error-column errors))
-         (column-range (cons (apply 'min columns) (apply 'max columns))))
+         (columns (seq-filter 'null (mapcar 'flycheck-error-column errors)))
+         (column-range (and columns
+                            (cons (apply 'min columns) (apply 'max columns)))))
     (mapc #'flycheck-inline-display-error
           (seq-filter
            (lambda (error)
@@ -241,10 +242,12 @@ ERRORS is a list of `flycheck-error' objects."
                (and
                 (>= line (car line-range))
                 (<= line (cdr line-range))
-                (>= column (car column-range))
-                (<= column (cdr column-range)))))
-           (seq-uniq
-            (seq-mapcat #'flycheck-related-errors errors))))))
+                (or (and column-range column
+                         (>= column (car column-range))
+                         (<= column (cdr column-range))
+                         t))))
+             (seq-uniq
+              (seq-mapcat #'flycheck-related-errors errors)))))))
 
 
 ;;; Global and local minor modes


### PR DESCRIPTION
For some checkers, sometimes the entire line can be just a single error and that error will not have any column info, in that case `flycheck-inline-display-errors` will raise a `(wrong-type-argument number-or-marker-p nil)` when trying to get the min of a list of nils. This PR fixes this issue.

@bbatsov 