### PR TITLE
fix seq-filter args

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -245,9 +245,9 @@ ERRORS is a list of `flycheck-error' objects."
                 (or (and column-range column
                          (>= column (car column-range))
                          (<= column (cdr column-range))
-                         t))))
-             (seq-uniq
-              (seq-mapcat #'flycheck-related-errors errors)))))))
+                         t)))))
+           (seq-uniq
+            (seq-mapcat #'flycheck-related-errors errors))))))
 
 
 ;;; Global and local minor modes


### PR DESCRIPTION
There was a misaligned closing paren from #26 , so seq-filter was only called with 1 argument instead of 2.

@bbatsov 