### PR TITLE
Really filter out errors with no columns

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -231,7 +231,7 @@ ERRORS is a list of `flycheck-error' objects."
   (flycheck-inline-hide-errors)
   (let* ((lines (mapcar 'flycheck-error-line errors))
          (line-range (cons (apply 'min lines) (apply 'max lines)))
-         (columns (seq-filter 'null (mapcar 'flycheck-error-column errors)))
+         (columns (seq-filter 'identity (mapcar 'flycheck-error-column errors)))
          (column-range (and columns
                             (cons (apply 'min columns) (apply 'max columns)))))
     (mapc #'flycheck-inline-display-error
@@ -244,8 +244,8 @@ ERRORS is a list of `flycheck-error' objects."
                 (<= line (cdr line-range))
                 (or (and column-range column
                          (>= column (car column-range))
-                         (<= column (cdr column-range))
-                         t)))))
+                         (<= column (cdr column-range)))
+                    t))))
            (seq-uniq
             (seq-mapcat #'flycheck-related-errors errors))))))
 


### PR DESCRIPTION
- filter _out_ instead of filter _for_ null columns
- the error should display even without columns

This fixes the brain fart when addressing the review comments in #26 

@bbatsov 